### PR TITLE
Minimization version 1.1.1

### DIFF
--- a/Minimization.php
+++ b/Minimization.php
@@ -350,7 +350,7 @@ class Minimization extends \ExternalModules\AbstractExternalModule
 				$irStratField = $listIRStratFields[$i];
 				if ( $infoNewRecord[$irStratEvent][$irStratField] == '' )
 				{
-					return $this->logRandoFailure( "Field $stratField missing.", $newRecordID );
+					return $this->logRandoFailure( "Field $irStratField missing.", $newRecordID );
 				}
 				$listIRStratValues[$irStratEvent][$irStratField] =
 						$infoNewRecord[$irStratEvent][$irStratField];
@@ -527,6 +527,12 @@ class Minimization extends \ExternalModules\AbstractExternalModule
 		{
 			// Get the existing record's randomization allocation.
 			$existingCode = $infoRecord[$randoEvent][$randoField];
+			if ( ! in_array( $existingCode, $listRandoCodes ) )
+			{
+				// If the existing record's allocation is not one of the defined allocation codes,
+				// then skip it.
+				continue;
+			}
 			for ( $i = 0; $i < count( $listMinFields ); $i++ )
 			{
 				// Increment the minimization totals where the minimization field value on the new


### PR DESCRIPTION
This update to the minimization module incorporates the following changes:

* Bug fix: When randomizing, if there are any records in the strata which are assigned to an allocation which is not defined in the module settings (for the minimization mode), e.g. if an allocation was removed, then these records are to be ignored. This corrects an issue causing the diagnostic data to not be saved.
* Bug fix: Corrected a variable name so when the initial random strata is used and a field for the initial random strata is missing/empty, the correct field name will be shown in the error message and log.